### PR TITLE
added self destructing contract test

### DIFF
--- a/tests/fixtures/app38-self_destructing_contracts_test/dummyFactory.sol
+++ b/tests/fixtures/app38-self_destructing_contracts_test/dummyFactory.sol
@@ -1,0 +1,19 @@
+import "./mortal.sol";
+
+contract Dummy is mortal {}
+
+contract DummyFactory {
+
+  Dummy _dummy;
+
+  // create a new contract, the factory is the owner
+  function createADummy(){
+    _dummy = (new Dummy).value(msg.value)();
+  }
+
+  // destroy: should be allowed since the factory is the owner
+  function destroyADummy() returns (bool) {
+    _dummy.destroy();
+    return true;
+  }
+}

--- a/tests/fixtures/app38-self_destructing_contracts_test/epm.yaml
+++ b/tests/fixtures/app38-self_destructing_contracts_test/epm.yaml
@@ -1,0 +1,126 @@
+jobs:
+
+#first test that we can kill the dummy ourselves
+- name: sendTxQuery1
+  job:
+    query-account:
+      account: $addr1
+      field: balance
+
+- name: deployDummy
+  job:
+    deploy:
+      from: $addr1
+      contract: dummyFactory.sol
+      instance: Dummy
+      amount: 5000
+      wait: true
+
+- name: sendTxQuery2
+  job:
+    query-account:
+      account: $addr1
+      field: balance
+
+- name: assertBalanceWithdrawn
+  job:
+    assert:
+      key: $sendTxQuery1
+      relation: gt
+      val: $sendTxQuery2
+
+- name: testDummy
+  job:
+    call:
+      destination: $deployDummy
+      function: destroy
+      wait: true
+
+#- name: sendTxQuery3
+#  job:
+#    query-account:
+#      account: $deployDummy
+#      field: balance
+
+- name: sendTxQuery4
+  job:
+    query-account:
+      account: $addr1
+      field: balance
+
+#- name: assertContractEmpty
+#  job:
+#    assert:
+#      key: $sendTxQuery3
+#      relation: eq
+#      val: 0
+
+#- name: assertBalanceRestored
+#  job:
+#    assert:
+#      key: $sendTxQuery1
+#      relation: eq
+#      val: $sendTxQuery4
+
+# Now test that we can do this with a factory
+
+- name: deployDummyFactory
+  job:
+    deploy:
+      contract: dummyFactory.sol
+      instance: DummyFactory
+      wait: true
+
+#- name: setOriginalBalance
+#  job:
+#    query-account:
+#      account: $deployDummyFactory
+#      field: balance
+
+- name: testDummyCreation
+  job:
+    call:
+      destination: $deployDummyFactory
+      function: createADummy
+      amount: 5000
+      wait: true
+
+#- name: checkDummyFactoryBalance
+#  job:
+#    query-account:
+#      account: $deployDummyFactory
+#      field: balance
+
+#- name: assertStillSame
+#  job:
+#    assert:
+#      key: $setOriginalBalance
+#      relation: eq
+#      val: $checkDummyFactoryBalance
+
+- name: testDummyDestruction
+  job:
+    call:
+      destination: $deployDummyFactory
+      function: destroyADummy
+      wait: true
+
+- name: assertDummyDestroyed
+  job:
+    assert:
+      key: $testDummyDestructionm
+      relation: eq
+      val: "true"
+
+#- name: checkDummyFactoryBalance2
+#  job:
+#    query-account:
+#      account: $deployDummyFactory
+#      field: balance
+
+#- name: assertBalanceGreater
+#  job:
+#    assert:
+#      key: $setOriginalBalance
+#      relation: lt
+#      val: $checkDummyFactoryBalance2

--- a/tests/fixtures/app38-self_destructing_contracts_test/mortal.sol
+++ b/tests/fixtures/app38-self_destructing_contracts_test/mortal.sol
@@ -1,0 +1,7 @@
+import "./owned.sol";
+
+contract mortal is owned {
+    function destroy() onlyOwner {
+      selfdestruct(owner);
+    }
+}

--- a/tests/fixtures/app38-self_destructing_contracts_test/owned.sol
+++ b/tests/fixtures/app38-self_destructing_contracts_test/owned.sol
@@ -1,0 +1,14 @@
+contract owned {
+    address owner;
+
+    modifier onlyOwner() {
+        if (msg.sender == owner) {
+            _
+        }
+    }
+
+    function owned() {
+        owner = msg.sender;
+    }
+
+}

--- a/tests/fixtures/app38-self_destructing_contracts_test/readme.md
+++ b/tests/fixtures/app38-self_destructing_contracts_test/readme.md
@@ -1,0 +1,1 @@
+* test self destructing contracts


### PR DESCRIPTION
Two problems have been identified in this test:

1. Cannot get the account balance from a contract address...this needs to be rectified.
2. There appears to be an infinite loop on a selfdestruct command, but what's interesting is that it only manifests when it is contract->contract calling the selfdestructing contract, and doesn't manifest whenever it is account->contract calling the selfdestruct. 

@benjaminbollen @silasdavis use this test when solving these problems. 
