### PR TITLE
docs: cleanup throughout

### DIFF
--- a/docs/chain-deploying.md
+++ b/docs/chain-deploying.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 <div class="note">
-   <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 ## Introduction

--- a/docs/chain-making.md
+++ b/docs/chain-making.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 <div class="note">
-   <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 ## Introduction

--- a/docs/deploying-advanced-smart-contracts-to-a-chain.md
+++ b/docs/deploying-advanced-smart-contracts-to-a-chain.md
@@ -13,7 +13,7 @@ menu:
 ## Introduction
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 For this tutorial, we are going to work with multiple contracts. All the base contract does is get and sets a value, but we'll add some layers to the contract which will satisfy common patterns smart contract writers adopt.
@@ -54,7 +54,7 @@ So let's go through them one by one and explain what each of these jobs are doin
 
 #### Job 1: Deploy Job
 
-This job will compile the `GSFactory.sol` contracts using Eris' compiler service (or run your own locally; which will be covered later in this tutorial). But which contract(s) will get deployed even though they both are in the contract? When we have more than one contract in a file, we tell the package manager which one it should deploy with the `instance` field.
+This job will compile the `GSFactory.sol` contracts using the compiler service (or run your own locally; which will be covered later in this tutorial). But which contract(s) will get deployed even though they both are in the contract? When we have more than one contract in a file, we tell the package manager which one it should deploy with the `instance` field.
 
 Here we are asking the package manager to deploy `all` of the contracts so that we will have an ABI for the `GSContract` address. This is something important to understand about Factory contracts. Namely that at some point you will have to deploy a "fake" contract to your chain so that the ABI for it is properly saved to the ABI folder.
 

--- a/docs/deprecated/bond-unbond.md
+++ b/docs/deprecated/bond-unbond.md
@@ -9,7 +9,7 @@ title: "Deprecated | Bonding/Unbonding"
 ## Introduction
 
 <div class="note">
-  <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 The concept of bonding/unbonding validators here refers to validators which are voluntarily adding (bonding) or removing (unbonding) themselves. New validators (not included in the genesis file) first require tokens on the chain to post a bond with. Future tutorials will cover slashing/removing unwelcome/byzantine validators.

--- a/docs/deprecated/chain-maintaining.md
+++ b/docs/deprecated/chain-maintaining.md
@@ -9,10 +9,10 @@ title: "Deprecated | Chain Maintaining"
 ## Introduction
 
 <div class="note">
-  <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
-In general what is going to happen here is that we are going to establish what we at Eris call a "peer sergeant major" node who is responsible for being the easy connection point for any nodes which need to connect into the system. While we understand that decentralized purists will not like the single point of failure, at this point it is the most viable way to orchestrate a blockchain network.
+In general what is going to happen here is that we are going to establish what we at Monax call a "peer sergeant major" node who is responsible for being the easy connection point for any nodes which need to connect into the system. While we understand that decentralized purists will not like the single point of failure, at this point it is the most viable way to orchestrate a blockchain network.
 
 In addition to the one "peer sergeant major" we will also deploy six "peer sergeants" who will be cloud based validator nodes.
 

--- a/docs/deprecated/exporting_your_keys.md
+++ b/docs/deprecated/exporting_your_keys.md
@@ -9,7 +9,7 @@ title: "Deprecated | Exporting Your Keys"
 ## Introduction
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 Unless you have a different configuration than our standard, admittedly opinionated, pathway then you will be running the eris-keys signing server inside of a container. This means that you need to be able to import and export your keys. This tutorial covers the existing `eris keys` commands and working with keys vis-a-vis containers on the eris platform.

--- a/docs/deprecated/genesis_updating.md
+++ b/docs/deprecated/genesis_updating.md
@@ -9,7 +9,7 @@ title: "Deprecated | Genesis Updating"
 ## Introduction
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.
+{{ data_sites rename_docs }}
 </div>
 
 All eris:db use a genesis.json to get started. The genesis.json tells eris:db:

--- a/docs/deprecated/getting_started_with_cloud_instances.md
+++ b/docs/deprecated/getting_started_with_cloud_instances.md
@@ -9,7 +9,7 @@ title: "Deprecated | Getting Started With Cloud Instances"
 ## Introduction
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This tutorial will cover the first step when seeking to install Eris on cloud providers. Covered in this tutorial are the following cloud providers:

--- a/docs/deprecated/how_to_make_a_service.md
+++ b/docs/deprecated/how_to_make_a_service.md
@@ -9,7 +9,7 @@ title: "Deprecated | How To Make A Service"
 ## Introduction
 
 <div class="note">
-  <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 We are going to change the old idi contract so that it does a few things for us, which will be helpful for us to learn about Docker and Eris later.

--- a/docs/deprecated/install-arm.md
+++ b/docs/deprecated/install-arm.md
@@ -9,7 +9,7 @@ aliases:
 ## Introduction
 
 <div class="note">
-  <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This tutorial uses Raspberry Pi 3 as referenced IoT device to demonstrate how to install eris blockchain tools on IoT devices.

--- a/docs/deprecated/using_docker_machine_with_eris.md
+++ b/docs/deprecated/using_docker_machine_with_eris.md
@@ -9,7 +9,7 @@ title: "Deprecated | Using Docker Machine With Eris"
 ## Introduction
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This tutorial will provide an overview of working with [docker-machine](https://docs.docker.com/machine/), a nifty tool for managing and deploying docker hosts.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,12 +11,12 @@ menu:
 ---
 
 <div class="note">
-   <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
-Eris is the ecosystem application platform built by `Monax`.
+`monax` is the CLI ecosystem application platform built by Monax.
 
-There are four steps need to get moving with Eris:
+There are four steps need to get moving with Monax:
 
 1. **Install** the platform.
 2. **Roll** the blockchain base for your ecosystem application.
@@ -56,9 +56,9 @@ Make sure that everything is set up with Docker by running (you shouldn't see an
 docker version
 ```
 
-**Note** you will need to make sure that you perform the above command for the *user* which will be running Eris.
+**Note** you will need to make sure that you perform the above command for the *user* which will be running Monax.
 
-If you've also chosen to install Docker Machine, please follow [these](https://docs.docker.com/machine/install-machine/#installing-machine-directly) instructions to install Docker Machine and [these](https://www.virtualbox.org/wiki/Linux_Downloads) to install VirtualBox; then create an Eris virtual machine and run the (`eval`) command:
+If you've also chosen to install Docker Machine, please follow [these](https://docs.docker.com/machine/install-machine/#installing-machine-directly) instructions to install Docker Machine and [these](https://www.virtualbox.org/wiki/Linux_Downloads) to install VirtualBox; then create an Monax virtual machine and run the (`eval`) command:
 
 ```bash
 docker-machine create -d virtualbox monax
@@ -108,7 +108,7 @@ We **highly recommend** that you utilize [Homebrew](https://brew.sh) to install 
 {{< data_coding brew >}}
 ```
 
-If you are not a `brew` user then please install Docker, Docker machine, and VirtualBox by installing [Docker Toolbox](https://www.docker.com/products/docker-toolbox) and Eris binary from the [Release](https://github.com/monax/cli/releases) page. Make sure you put the binary under one of the paths in your `$PATH` variable and it has executable permissions:
+If you are not a `brew` user then please install Docker, Docker machine, and VirtualBox by installing [Docker Toolbox](https://www.docker.com/products/docker-toolbox) and Monax binary from the [Release](https://github.com/monax/cli/releases) page. Make sure you put the binary under one of the paths in your `$PATH` variable and it has executable permissions:
 
 ```bash
 curl -L https://github.com/monax/cli/releases/download/v0.16.0/monax_0.16.0_darwin_amd64 > monax
@@ -117,7 +117,7 @@ chmod +x monax
 
 If you don't want to utilize Docker Toolbox, you can install those manually: follow [these](https://docs.docker.com/installation/) instructions to install Docker, [these](https://docs.docker.com/machine/install-machine/#installing-machine-directly) to install Docker Machine, and [these](https://www.virtualbox.org/wiki/Downloads) to install VirtualBox.
 
-If you have chosen not to use Docker Toolbox at all, you need to create an Eris virtual machine and run the (`eval`) command:
+If you have chosen not to use Docker Toolbox at all, you need to create an Monax virtual machine and run the (`eval`) command:
 
 ```bash
 docker-machine create -d virtualbox monax
@@ -142,14 +142,14 @@ We **highly recommend** that you utilize [Chocolatey](https://chocolatey.org) to
 {{< data_coding choco >}}
 ```
 
-If you are not a `choco` user then please install Docker, Docker Machine, and VirtualBox by downloading the [Docker Toolbox](https://www.docker.com/products/docker-toolbox) and Eris binary from the [Release](https://github.com/monax/cli/releases) page.
+If you are not a `choco` user then please install Docker, Docker Machine, and VirtualBox by downloading the [Docker Toolbox](https://www.docker.com/products/docker-toolbox) and Monax binary from the [Release](https://github.com/monax/cli/releases) page.
 Make sure you put the binary under one of the paths in your `%PATH%` variable.
 
 If you don't want to utilize Docker Toolbox, you can install those manually: follow [these](https://docs.docker.com/installation/) instructions to install Docker, [these](https://docs.docker.com/machine/install-machine/#installing-machine-directly) to install Docker Machine, and [these](https://www.virtualbox.org/wiki/Downloads) to install VirtualBox.
 
 (You'll want to run `monax` commands either from `git bash` or from the `Docker Quickstart Terminal`, a part of Docker Toolbox. If you prefer to use the `cmd` as your shell, you still can: every command should work as expected, though all the tutorials will assume that you are using the `Docker Quickstart Terminal` and are structured to support **only** that environment.)
 
-If you have chosen not to use Docker Toolbox at all and use `cmd` as your shell, you need to create an Eris virtual machine:
+If you have chosen not to use Docker Toolbox at all and use `cmd` as your shell, you need to create an Monax virtual machine:
 
 ```bash
 docker-machine create -d virtualbox monax

--- a/docs/install-source.md
+++ b/docs/install-source.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 You will need `go` and `git` installed to do this.
@@ -42,9 +42,9 @@ export PATH="$GOBIN:$PATH"
 
 If you do not add those lines to the relevant shell files then you can just type them into the shell each time you log in. You can check that this change was added by running the `echo $PATH|tr ':' '\n'` command and making sure that your path has been updated appropriately.
 
-Now you're ready to install the components of the Eris platform.
+Now you're ready to install the components of the Monax platform.
 
-## Building Eris from source
+## Building Monax from source
 
 Go makes it very easy to build from source. Indeed, it is really only one command.
 

--- a/docs/install-troubleshooting.md
+++ b/docs/install-troubleshooting.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 ## I'm On macOS or Windows and It's All Wonky!
@@ -39,7 +39,7 @@ If you type `monax init` or `monax init --debug` and you get **no** output, this
 sudo usermod -a -G docker $USER
 ```
 
-From the user who will be using Eris.
+From the user who will be using Monax.
 
 You will need to close the terminal window and open a new terminal for the changes to take effect. If you are `ssh`-ing into a cloud based development machine, then log out and log back in so that the changes will take effect.
 
@@ -49,13 +49,13 @@ Double check that your changes have taken hold (after you log back in or in a ne
 groups $USER
 ```
 
-From the user who will be using Eris.
+From the user who will be using Monax.
 
 Confirm that the line output includes `docker` and you will be good to go!
 
 ## Can't See What's Happening?
 
-By default, `monax` is a fairly quiet tool. If you would like to have more output you can add `-v` (for verbose) **or** `-d` (for debug) to any command in order to see more output. In general, there is no need to use *both* of these flags. The `--verbose` flag will give a bit more output than the command will by default and the `--debug` flag will give *much* more output than the either the `--verbose` flag or the command by default, but will be directed primarily at Eris developers.
+By default, `monax` is a fairly quiet tool. If you would like to have more output you can add `-v` (for verbose) **or** `-d` (for debug) to any command in order to see more output. In general, there is no need to use *both* of these flags. The `--verbose` flag will give a bit more output than the command will by default and the `--debug` flag will give *much* more output than the either the `--verbose` flag or the command by default, but will be directed primarily at Monax developers.
 
 If you are reporting a bug, please rerun the command which caused the issue with the debug flag (`-d` or `--debug`) and send us the output to a [Github Issue](https://github.com/monax/cli/issues/new) or via Community Driven [Support Forums](https://support.monax.io).
 
@@ -67,7 +67,7 @@ Docker itself needs to be given a proxy. You can do this by updating your `/etc/
 export http_proxy="http://myproxy.com"
 ```
 
-Some organizations do not allow connections to [quay.io](https://quay.io) (which is an equivalent to [Docker Hub](https://hub.docker.com) but with many more security features). At Eris we keep most of our Docker images on quay.io. At this time we are working on an automatic bridge script which will mirror our quay.io images to [Docker Hub](https://hub.docker.com) but that is still a work in progress. As such you will likely need to ensure your computer can access [quay.io](https://quay.io).
+Some organizations do not allow connections to [quay.io](https://quay.io) (which is an equivalent to [Docker Hub](https://hub.docker.com) but with many more security features). At Monax we keep most of our Docker images on quay.io. At this time we are working on an automatic bridge script which will mirror our quay.io images to [Docker Hub](https://hub.docker.com) but that is still a work in progress. As such you will likely need to ensure your computer can access [quay.io](https://quay.io).
 
 
 ## [<i class="fa fa-chevron-circle-left" aria-hidden="true"></i> All Tutorials](/docs/)

--- a/docs/known-chain-making.md
+++ b/docs/known-chain-making.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 There are three steps to making a permissioned chain with known keys:

--- a/docs/solidity/index.md
+++ b/docs/solidity/index.md
@@ -14,7 +14,7 @@ menu:
 ## Solidity Series
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This sequence of tutorials assumes that you have an understanding of the `monax` tooling to the point we ended in our [101 tutorial sequence](/docs/getting-started/).

--- a/docs/solidity/solidity_1_the_five_types_model.md
+++ b/docs/solidity/solidity_1_the_five_types_model.md
@@ -8,7 +8,7 @@ title: "Tutorials | Solidity 1: The Five Types Model"
 ## Solidity Series
 
 <div class="note">
-    <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This sequence of tutorials assumes that you have an understanding of the `monax` tooling to the point we ended in our [101 tutorial sequence](/docs/getting-started/).

--- a/docs/solidity/solidity_2_action_driven_architecture.md
+++ b/docs/solidity/solidity_2_action_driven_architecture.md
@@ -8,7 +8,7 @@ title: "Tutorials | Solidity 2: An Action-Driven Architecture"
 ## Solidity Series
 
 <div class="note">
-  <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This sequence of tutorials assumes that you have an understanding of the `monax` tooling to the point we ended in our [101 tutorial sequence](/docs/getting-started/).
@@ -776,7 +776,7 @@ function getAllElements(){
 }
 ```
 
-Note that accessing the element data by index is a bit ugly. Personally I use the json ABI to generate objects of the returned data with the proper names etc., using something like this (which will also be in Eris js):
+Note that accessing the element data by index is a bit ugly. Personally I use the json ABI to generate objects of the returned data with the proper names etc., using something like this (which will also be in Monax.js):
 
 ```javascript
 // fName = function name.

--- a/docs/solidity/solidity_3_solidity_language_features.md
+++ b/docs/solidity/solidity_3_solidity_language_features.md
@@ -8,7 +8,7 @@ title: "Tutorials | Solidity 3: Solidity Language Features"
 ## Solidity Series
 
 <div class="note">
-  <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This sequence of tutorials assumes that you have an understanding of the `monax` tooling to the point we ended in our [101 tutorial sequence](/docs/getting-started/).

--- a/docs/solidity/solidity_4_testing_solidity.md
+++ b/docs/solidity/solidity_4_testing_solidity.md
@@ -8,7 +8,7 @@ title: "Tutorials | Solidity 4: Testing Solidity"
 ## Solidity Series
 
 <div class="note">
-  <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This sequence of tutorials assumes that you have an understanding of the `monax` tooling to the point we ended in our [101 tutorial sequence](/docs/getting-started/).
@@ -398,7 +398,7 @@ The full, working version of this contract (including Asserter.sol and other thi
 
 Proper tests for smart-contracts will soon become the standard. This means real, well-designed, multi-level tests and not just some crappy javascript calling some function then checking the return value; however, unit testing is not all. Another thing I believe that a serious Solidity project should have is a proper workspace, with the files laid out as they would in any other code project, and a clear system for building and deploying.
 
-Javascript is good. It has become the de facto language not just for the web, but DApps as well. The Eris stack supports javascript (`Node.js` in particular). This support includes an API for the blockchain client, and our `legacy-contracts` library for talking to solidity contracts.
+Javascript is good. It has become the de facto language not just for the web, but DApps as well. The Monax stack supports javascript (`Node.js` in particular). This support includes an API for the blockchain client, and our `legacy-contracts` library for talking to solidity contracts.
 
 One of the best things with `Node.js` integration is that we get full access to its tools. [gulp](https://github.com/gulpjs/gulp) is particularly useful. It's a very popular build-automation tool that lets you create different tasks, chain them, and many other things. There's also a unit-testing framework called [mocha](https://github.com/mochajs/mocha), and a bunch of different assertion libraries. Since `solUnit` is a node.js library, it is possible to run the tests from mocha, and thereby integrating the Solidity tests with the tests of other DApp code (at least if it is `node.js` javascript).
 

--- a/docs/solidity/solidity_5_modular_solidity.md
+++ b/docs/solidity/solidity_5_modular_solidity.md
@@ -8,7 +8,7 @@ title: "Tutorials | Solidity 5: Modular design and strategies"
 ## Solidity Series
 
 <div class="note">
-    <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This sequence of tutorials assumes that you have an understanding of the `eris` tooling to the point we ended in our [101 tutorial sequence](/docs/getting-started/).

--- a/docs/solidity/solidity_6_advanced_solidity_features.md
+++ b/docs/solidity/solidity_6_advanced_solidity_features.md
@@ -8,7 +8,7 @@ title: "Tutorials | Solidity 6: Advanced Solidity Features"
 ## Solidity Series
 
 <div class="note">
-  <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This sequence of tutorials assumes that you have an understanding of the `monax` tooling to the point we ended in our [101 tutorial sequence](/docs/getting-started/).

--- a/docs/solidity/solidity_7_updating_solidity_contracts.md
+++ b/docs/solidity/solidity_7_updating_solidity_contracts.md
@@ -8,7 +8,7 @@ title: "Tutorials | Solidity 7: Updating Solidity Contracts"
 ## Solidity Series
 
 <div class="note">
-    <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 This sequence of tutorials assumes that you have an understanding of the `monax` tooling to the point we ended in our [101 tutorial sequence](/docs/getting-started/).

--- a/docs/specs/asserts_specification.md
+++ b/docs/specs/asserts_specification.md
@@ -9,7 +9,7 @@ title: "Specifications | Assert Jobs Specification"
 ## Assert Jobs Specification
 
 <div class="note">
-  <em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 Asserts can be used to compare two "things". These "things" may be the result of two jobs or the result against one job against a baseline. (Indeed, it could be the comparison of two baselines but that wouldn't really get folks anywhere).

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -14,7 +14,7 @@ menu:
 ## Specifications
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.monax</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 
@@ -24,7 +24,7 @@ Services are defined in **service definition files**. These reside on the host i
 
 Service definition files are formatted using `toml`.
 
-[Read the Services Specification &nbsp;<i class="fa fa-chevron-circle-right" aria-hidden="true"></i>](docs/specs/services_specification)
+[Read the Services Specification &nbsp;<i class="fa fa-chevron-circle-right" aria-hidden="true"></i>](/docs/specs/services_specification)
 
 
 ### Jobs Specification
@@ -37,11 +37,11 @@ Job definition files are formatted in `yaml` and default file is `epm.yaml`.
 
 Examples of monax job definition files are available in the [jobs_fixtures](https://github.com/monax/cli/tree/master/tests/jobs_fixtures) directory.
 
-[Read the Jobs Specification &nbsp;<i class="fa fa-chevron-circle-right" aria-hidden="true"></i>](docs/specs/jobs_specification)
+[Read the Jobs Specification &nbsp;<i class="fa fa-chevron-circle-right" aria-hidden="true"></i>](/docs/specs/jobs_specification)
 
 
 
-## [<i class="fa fa-chevron-circle-left" aria-hidden="true"></i> All Tutorials](docs/)
+## [<i class="fa fa-chevron-circle-left" aria-hidden="true"></i> All Tutorials](/docs/)
 
 
 

--- a/docs/specs/jobs_specification.md
+++ b/docs/specs/jobs_specification.md
@@ -9,7 +9,7 @@ title: "Specifications | Jobs Specification"
 ## Jobs Specification
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 The goal of jobs is to enable automation of contractual steps and defining "use" for a package of smart contracts. While one might deploy utility contracts that can be shared broadly and used by many a developer, jobs allows one to execute a package of contracts as it was intended and purposed to do and allows this execution to be replicated on thousands of chains, thus enabling what we call "dual integration" so that smart contracts can then be potentially represented as real life contracts. Rather than creating an entire web app, one can also simply test all of their smart contracts through a yaml config file in the form of the `epm.yaml` file. This enables quick deployment and testing of smart contract functionality. 
@@ -18,7 +18,7 @@ When combined with a package manager to install and resolve dependencies, one ca
 
 Examples of monax job definition files are available in the [jobs_fixtures](https://github.com/monax/cli/tree/master/tests/jobs_fixtures) directory.
 
-Each job will perform its required action and then it will save the result of its job in a variable which can be utilized by jobs later in the sequence using the job runner' [variable specification](docs/specs/variable_specification).
+Each job will perform its required action and then it will save the result of its job in a variable which can be utilized by jobs later in the sequence using the job runner' [variable specification](/docs/specs/variable_specification).
 
 By default, `monax pkgs do` will perform the entire sequence of jobs which has been outlined in a given jobs file.
 
@@ -277,7 +277,7 @@ Ex.
 
 Asserts can be used to compare two "things". These "things" may be the result of two jobs or the result against one job against a baseline. (Indeed, it could be the comparison of two baselines but that wouldn't really get folks anywhere).
 
-[Read the Assert Jobs Specification &nbsp;<i class="fa fa-chevron-circle-right" aria-hidden="true"></i>](docs/specs/asserts_specification)
+[Read the Assert Jobs Specification &nbsp;<i class="fa fa-chevron-circle-right" aria-hidden="true"></i>](/docs/specs/asserts_specification)
 
 ### Utility Jobs
 
@@ -319,4 +319,4 @@ jobs:
 ### Extension/Creating your own Job - Coming soon!
 
 
-## [<i class="fa fa-chevron-circle-left" aria-hidden="true"></i> All Specifications](docs/specs)
+## [<i class="fa fa-chevron-circle-left" aria-hidden="true"></i> All Specifications](/docs/specs)

--- a/docs/specs/services_specification.md
+++ b/docs/specs/services_specification.md
@@ -9,7 +9,7 @@ title: "Specifications | Services Specification"
 ## Services Specification
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 Services are defined in **service definition files**. These reside on the host in `~/.monax/services`.

--- a/docs/specs/variable_specification.md
+++ b/docs/specs/variable_specification.md
@@ -9,7 +9,7 @@ title: "Specifications | Variables Specification"
 ## Variables Specification
 
 <div class="note">
-	<em>Note: As of 2017, our product has been renamed from Eris to Monax. This documentation refers to an earlier version of the software prior to this name change (<= 0.16). Later versions of this documentation (=> 0.17) will change the <code>eris</code> command and <code>~/.eris</code> directory to <code>monax</code> and <code>~/.monax</code> respectively.</em>
+{{ data_sites rename_docs }}
 </div>
 
 Variables can be used for nearly every monax [jobs](/docs/specs/jobs_specification) field (largely with the exception of nonce and wait).


### PR DESCRIPTION
move the re-name note to website as `{{ site_date rename_docs }}` for simplicity & fix latents names & URLs