### PR TITLE
Update Chain maker Usage of Ints to Bool / Change monax namespace to hyperledger

### DIFF
--- a/chains/maker/accounts.go
+++ b/chains/maker/accounts.go
@@ -10,8 +10,8 @@ import (
 	"github.com/monax/cli/keys"
 	"github.com/monax/cli/log"
 
-	"github.com/monax/burrow/genesis"
-	ptypes "github.com/monax/burrow/permission/types"
+	"github.com/hyperledger/burrow/genesis"
+	ptypes "github.com/hyperledger/burrow/permission/types"
 )
 
 // MonaxDBAccountConstructor contains different views on a single account

--- a/chains/maker/files.go
+++ b/chains/maker/files.go
@@ -11,8 +11,8 @@ import (
 	"github.com/monax/cli/definitions"
 	"github.com/monax/cli/log"
 
-	configurationFile "github.com/monax/burrow/config"
-	"github.com/monax/burrow/genesis"
+	configurationFile "github.com/hyperledger/burrow/config"
+	"github.com/hyperledger/burrow/genesis"
 
 	"github.com/BurntSushi/toml"
 )

--- a/chains/maker/maker.go
+++ b/chains/maker/maker.go
@@ -12,7 +12,7 @@ import (
 	"github.com/monax/cli/log"
 	"github.com/monax/cli/util"
 
-	"github.com/monax/burrow/genesis"
+	"github.com/hyperledger/burrow/genesis"
 )
 
 var (
@@ -163,7 +163,7 @@ func assembleTypesWizard(accountT *definitions.MonaxDBAccountType, tokenIze bool
 		}
 	}
 
-	if accountT.Perms["bond"] == 1 && accountT.DefaultNumber > 0 {
+	if accountT.Perms["bond"] == true && accountT.DefaultNumber > 0 {
 		accountT.DefaultBond, err = util.GetIntResponse(AccountTypeToBond(accountT), accountT.DefaultBond, reader)
 		log.WithField("=>", accountT.DefaultBond).Debug("What the marmots heard")
 		if err != nil {
@@ -199,9 +199,9 @@ func addManualAccountType(accountT []*definitions.MonaxDBAccountType, iterator i
 		return nil, err
 	}
 
-	thisActT.Perms = make(map[string]int64)
+	thisActT.Perms = make(map[string]bool)
 	for _, perm := range AccountTypeManualPerms() {
-		thisActT.Perms[perm], err = util.GetIntResponse(AccountTypeManualPermsQuestion(perm), 0, reader)
+		thisActT.Perms[perm], err = util.GetBoolResponse(AccountTypeManualPermsQuestion(perm), false, reader)
 	}
 
 	name, err := util.GetStringResponse(AccountTypeManualSave(), "", reader)
@@ -271,9 +271,9 @@ func assembleTypesCSV(accountT []*definitions.MonaxDBAccountType, do *definition
 				if err != nil {
 					return err
 				}
-				permsPrime := make(map[string]int64)
+				permsPrime := make(map[string]bool)
 				for i := 0; i < len(perms); i++ {
-					p, err := strconv.ParseInt(perms[i+1], 10, 64)
+					p, err := strconv.ParseBool(perms[i+1])
 					if err != nil {
 						return err
 					}

--- a/chains/maker/nodes.go
+++ b/chains/maker/nodes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/monax/cli/log"
 
-	"github.com/monax/burrow/genesis"
+	"github.com/hyperledger/burrow/genesis"
 )
 
 // MakeMonaxDBNode writes the chain name folder with a folder for every account.

--- a/definitions/account_types.go
+++ b/definitions/account_types.go
@@ -1,13 +1,13 @@
 package definitions
 
 type MonaxDBAccountType struct {
-	Name          string           `mapstructure:"name" json:"name" yaml:"name" toml:"name"`
-	Description   string           `mapstructure:"description" json:"description" yaml:"description" toml:"description"`
-	TypicalUser   string           `mapstructure:"typical_user" json:"typical_user" yaml:"typical_user" toml:"typical_user"`
-	DefaultNumber int64            `mapstructure:"default_number" json:"default_number" yaml:"default_number" toml:"default_number"`
-	DefaultTokens int64            `mapstructure:"default_tokens" json:"default_tokens" yaml:"default_tokens" toml:"default_tokens"`
-	DefaultBond   int64            `mapstructure:"default_bond" json:"default_bond" yaml:"default_bond" toml:"default_bond"`
-	Perms         map[string]int64 `mapstructure:"perms" json:"perms" yaml:"perms" toml:"perms"`
+	Name          string          `mapstructure:"name" json:"name" yaml:"name" toml:"name"`
+	Description   string          `mapstructure:"description" json:"description" yaml:"description" toml:"description"`
+	TypicalUser   string          `mapstructure:"typical_user" json:"typical_user" yaml:"typical_user" toml:"typical_user"`
+	DefaultNumber int64           `mapstructure:"default_number" json:"default_number" yaml:"default_number" toml:"default_number"`
+	DefaultTokens int64           `mapstructure:"default_tokens" json:"default_tokens" yaml:"default_tokens" toml:"default_tokens"`
+	DefaultBond   int64           `mapstructure:"default_bond" json:"default_bond" yaml:"default_bond" toml:"default_bond"`
+	Perms         map[string]bool `mapstructure:"perms" json:"perms" yaml:"perms" toml:"perms"`
 }
 
 func BlankAccountType() *MonaxDBAccountType {

--- a/initialize/default_files.go
+++ b/initialize/default_files.go
@@ -193,22 +193,22 @@ privileges should be given these keys.
 Usually this group will have the most number of keys of all of the groups.`
 		accountTypeDefinition.DefaultNumber = 25
 		accountTypeDefinition.DefaultTokens = 9999999999
-		accountTypeDefinition.DefaultBond = 0
-		accountTypeDefinition.Perms = map[string]int64{
-			"root":            0,
-			"send":            1,
-			"call":            1,
-			"create_contract": 0,
-			"create_account":  0,
-			"bond":            0,
-			"name":            1,
-			"has_base":        0,
-			"set_base":        0,
-			"unset_base":      0,
-			"set_global":      0,
-			"has_role":        1,
-			"add_role":        0,
-			"rm_role":         0,
+		accountTypeDefinition.DefaultBond = 1
+		accountTypeDefinition.Perms = map[string]bool{
+			"root":            false,
+			"send":            true,
+			"call":            true,
+			"create_contract": false,
+			"create_account":  false,
+			"bond":            false,
+			"name":            true,
+			"has_base":        false,
+			"set_base":        false,
+			"unset_base":      false,
+			"set_global":      false,
+			"has_role":        true,
+			"add_role":        false,
+			"rm_role":         false,
 		}
 
 	case "developer":
@@ -224,21 +224,21 @@ within this group, although that design is up to you.`
 		accountTypeDefinition.DefaultNumber = 6
 		accountTypeDefinition.DefaultTokens = 9999999999
 		accountTypeDefinition.DefaultBond = 0
-		accountTypeDefinition.Perms = map[string]int64{
-			"root":            0,
-			"send":            1,
-			"call":            1,
-			"create_contract": 1,
-			"create_account":  1,
-			"bond":            0,
-			"name":            1,
-			"has_base":        0,
-			"set_base":        0,
-			"unset_base":      0,
-			"set_global":      0,
-			"has_role":        1,
-			"add_role":        1,
-			"rm_role":         1,
+		accountTypeDefinition.Perms = map[string]bool{
+			"root":            false,
+			"send":            true,
+			"call":            true,
+			"create_contract": true,
+			"create_account":  true,
+			"bond":            false,
+			"name":            true,
+			"has_base":        false,
+			"set_base":        false,
+			"unset_base":      false,
+			"set_global":      false,
+			"has_role":        true,
+			"add_role":        true,
+			"rm_role":         true,
 		}
 
 	case "validator":
@@ -256,21 +256,21 @@ in the system.`
 		accountTypeDefinition.DefaultNumber = 7
 		accountTypeDefinition.DefaultTokens = 9999999999
 		accountTypeDefinition.DefaultBond = 9999999998
-		accountTypeDefinition.Perms = map[string]int64{
-			"root":            0,
-			"send":            0,
-			"call":            0,
-			"create_contract": 0,
-			"create_account":  0,
-			"bond":            1,
-			"name":            0,
-			"has_base":        0,
-			"set_base":        0,
-			"unset_base":      0,
-			"set_global":      0,
-			"has_role":        0,
-			"add_role":        0,
-			"rm_role":         0,
+		accountTypeDefinition.Perms = map[string]bool{
+			"root":            false,
+			"send":            false,
+			"call":            false,
+			"create_contract": false,
+			"create_account":  false,
+			"bond":            true,
+			"name":            false,
+			"has_base":        false,
+			"set_base":        false,
+			"unset_base":      false,
+			"set_global":      false,
+			"has_role":        false,
+			"add_role":        false,
+			"rm_role":         false,
 		}
 
 	case "full":
@@ -287,21 +287,21 @@ If you are making a more complex chain, don't use this account type.`
 		accountTypeDefinition.DefaultNumber = 1
 		accountTypeDefinition.DefaultTokens = 99999999999999
 		accountTypeDefinition.DefaultBond = 9999999999
-		accountTypeDefinition.Perms = map[string]int64{
-			"root":            1,
-			"send":            1,
-			"call":            1,
-			"create_contract": 1,
-			"create_account":  1,
-			"bond":            1,
-			"name":            1,
-			"has_base":        1,
-			"set_base":        1,
-			"unset_base":      1,
-			"set_global":      1,
-			"has_role":        1,
-			"add_role":        1,
-			"rm_role":         1,
+		accountTypeDefinition.Perms = map[string]bool{
+			"root":            true,
+			"send":            true,
+			"call":            true,
+			"create_contract": true,
+			"create_account":  true,
+			"bond":            true,
+			"name":            true,
+			"has_base":        true,
+			"set_base":        true,
+			"unset_base":      true,
+			"set_global":      true,
+			"has_role":        true,
+			"add_role":        true,
+			"rm_role":         true,
 		}
 
 	case "root":
@@ -319,21 +319,21 @@ similar to a network administrator in other data management situations.`
 		accountTypeDefinition.DefaultNumber = 3
 		accountTypeDefinition.DefaultTokens = 9999999999
 		accountTypeDefinition.DefaultBond = 0
-		accountTypeDefinition.Perms = map[string]int64{
-			"root":            1,
-			"send":            1,
-			"call":            1,
-			"create_contract": 1,
-			"create_account":  1,
-			"bond":            1,
-			"name":            1,
-			"has_base":        1,
-			"set_base":        1,
-			"unset_base":      1,
-			"set_global":      1,
-			"has_role":        1,
-			"add_role":        1,
-			"rm_role":         1,
+		accountTypeDefinition.Perms = map[string]bool{
+			"root":            true,
+			"send":            true,
+			"call":            true,
+			"create_contract": true,
+			"create_account":  true,
+			"bond":            true,
+			"name":            true,
+			"has_base":        true,
+			"set_base":        true,
+			"unset_base":      true,
+			"set_global":      true,
+			"has_role":        true,
+			"add_role":        true,
+			"rm_role":         true,
 		}
 
 	default:

--- a/pkgs/abi/core.go
+++ b/pkgs/abi/core.go
@@ -8,11 +8,13 @@ import (
 	"strconv"
 	"strings"
 
-	ethAbi "github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/monax/cli/definitions"
 	"github.com/monax/cli/log"
 	"github.com/monax/cli/util"
+
+	ethAbi "github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 )
 
 func ReadAbiFormulateCall(abiLocation string, funcName string, args []string, do *definitions.Do) ([]byte, error) {
@@ -423,14 +425,14 @@ func getStringValue(value interface{}, typ ethAbi.Type) (string, error) {
 			case 8, 16, 32, 64:
 				return fmt.Sprintf("%v", value), nil
 			default:
-				return common.S256(value.(*big.Int)).String(), nil
+				return math.S256(value.(*big.Int)).String(), nil
 			}
 		case ethAbi.UintTy:
 			switch typ.Size {
 			case 8, 16, 32, 64:
 				return fmt.Sprintf("%v", value), nil
 			default:
-				return common.U256(value.(*big.Int)).String(), nil
+				return math.U256(value.(*big.Int)).String(), nil
 			}
 		case ethAbi.BoolTy:
 			return strconv.FormatBool(value.(bool)), nil

--- a/pkgs/jobs/jobs_contracts.go
+++ b/pkgs/jobs/jobs_contracts.go
@@ -15,11 +15,11 @@ import (
 
 	compilers "github.com/monax/compilers/perform"
 
-	"github.com/monax/burrow/client"
-	"github.com/monax/burrow/client/rpc"
-	"github.com/monax/burrow/keys"
-	"github.com/monax/burrow/logging/loggers"
-	"github.com/monax/burrow/txs"
+	"github.com/hyperledger/burrow/client"
+	"github.com/hyperledger/burrow/client/rpc"
+	"github.com/hyperledger/burrow/keys"
+	"github.com/hyperledger/burrow/logging/loggers"
+	"github.com/hyperledger/burrow/txs"
 )
 
 func PackageDeployJob(pkgDeploy *definitions.PackageDeploy, do *definitions.Do) (string, error) {

--- a/pkgs/jobs/jobs_test_jobs.go
+++ b/pkgs/jobs/jobs_test_jobs.go
@@ -10,8 +10,8 @@ import (
 	"github.com/monax/cli/pkgs/abi"
 	"github.com/monax/cli/util"
 
-	"github.com/monax/burrow/client"
-	"github.com/monax/burrow/logging/loggers"
+	"github.com/hyperledger/burrow/client"
+	"github.com/hyperledger/burrow/logging/loggers"
 )
 
 func QueryContractJob(query *definitions.QueryContract, do *definitions.Do) (string, []*definitions.Variable, error) {

--- a/pkgs/jobs/jobs_transact.go
+++ b/pkgs/jobs/jobs_transact.go
@@ -10,11 +10,11 @@ import (
 	"github.com/monax/cli/log"
 	"github.com/monax/cli/util"
 
-	"github.com/monax/burrow/client"
-	"github.com/monax/burrow/client/rpc"
-	"github.com/monax/burrow/keys"
-	"github.com/monax/burrow/logging/loggers"
-	"github.com/monax/burrow/txs"
+	"github.com/hyperledger/burrow/client"
+	"github.com/hyperledger/burrow/client/rpc"
+	"github.com/hyperledger/burrow/keys"
+	"github.com/hyperledger/burrow/logging/loggers"
+	"github.com/hyperledger/burrow/txs"
 )
 
 func SendJob(send *definitions.Send, do *definitions.Do) (string, error) {

--- a/util/chains_info.go
+++ b/util/chains_info.go
@@ -12,8 +12,8 @@ import (
 	"github.com/monax/cli/definitions"
 	"github.com/monax/cli/log"
 
-	"github.com/monax/burrow/client"
-	"github.com/monax/burrow/logging/loggers"
+	"github.com/hyperledger/burrow/client"
+	"github.com/hyperledger/burrow/logging/loggers"
 )
 
 // Maximum entries in the HEAD file

--- a/util/readers.go
+++ b/util/readers.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/monax/cli/log"
 
-	"github.com/monax/burrow/client/rpc"
+	"github.com/hyperledger/burrow/client/rpc"
 )
 
 // This is a closer function which is called by most of the tx_run functions


### PR DESCRIPTION
* This changes the usage of ints in golang to bools from the config files because that is what was being sent in anyway on the burrow side.
* This changes the namespace of monax/burrow to hyperledger/burrow. 

Note: relies on https://github.com/hyperledger/burrow/pull/569 and a subsequent vendor pull