### PR TITLE
services: remove some sub-commands

### DIFF
--- a/tests/test_chains_make.sh
+++ b/tests/test_chains_make.sh
@@ -23,7 +23,7 @@ export MONAX_MIGRATE_APPROVE="true"
 # Needed functionality
 
 ensure_running(){
-  if [[ "$($cli_exec services ls -qr | grep $1)" == "$1" ]]
+  if [[ "$($cli_exec ls -format {{.ShortName}} | grep $1)" == "$1" ]]
   then
     echo "$1 already started. Not starting."
     was_running=1

--- a/tests/test_jobs.sh
+++ b/tests/test_jobs.sh
@@ -51,7 +51,7 @@ repo=`pwd` #monax
 # Needed functionality
 
 ensure_running(){
-  if [[ "$($cli_exec services ls -qr | grep $1)" == "$1" ]]
+  if [[ "$($cli_exec ls --format {{.ShortName}} | grep $1)" == "$1" ]]
   then
     echo "$1 already started. Not starting."
     was_running=1


### PR DESCRIPTION
- removes a handful of sub-commands from the `monax services` command
- deprecates: `cat | edit | ls | inspect | update`
- these sub-commands did not add value to the `monax` tool and/or their purpose can be accomplished via other means. see #1349 for more info.
- this begins a move toward deprecating the `monax service` command entirely in order to reduce the surface area of the `monax` tool