### PR TITLE
chains: remove usage of mintkey

### DIFF
--- a/chains/chains.go
+++ b/chains/chains.go
@@ -426,27 +426,6 @@ func setupChain(do *definitions.Do) (err error) {
 		return fmt.Errorf("Could not import data: %v", err)
 	}
 
-	// mintkey has been removed from the monaxdb image. this functionality
-	// needs to be wholesale refactored. For now we'll just run the keys
-	// service (where mintkey is....)
-
-	importKey := definitions.NowDo()
-	importKey.Name = "keys"
-	importKey.Destination = containerDst
-	importKey.Source = filepath.Join(hostSrc, "priv_validator.json")
-	if err = data.ImportData(importKey); err != nil {
-		do.RmD = true
-		RemoveChain(do)
-		return fmt.Errorf("Could not import [priv_validator.json] to signer: %v", err)
-	}
-
-	if out, err := services.ExecHandler("keys", []string{"mintkey", "monax", fmt.Sprintf("%s/chains/%s/priv_validator.json", config.MonaxContainerRoot, do.Name)}); err != nil {
-		log.Error(err)
-		do.RmD = true
-		RemoveChain(do)
-		return fmt.Errorf("Failed to transliterate [priv_validator.json] to monax-key: %v", out)
-	}
-
 	log.WithFields(log.Fields{
 		"=>":              chain.Service.Name,
 		"links":           chain.Service.Links,

--- a/tests/test_jobs.sh
+++ b/tests/test_jobs.sh
@@ -96,8 +96,8 @@ test_setup(){
   echo -e "Backup Key =>\t\t\t\t$key2_addr"
   $cli_exec chains start $chain_name --init-dir $chain_dir/$name_full 1>/dev/null
   sleep 5 # boot time
-  chain_ip=$($cli_exec chains inspect $chain_name NetworkSettings.IPAddress)
-  keys_ip=$($cli_exec services inspect keys NetworkSettings.IPAddress)
+  chain_ip=$($cli_exec chains ip $chain_name)
+  keys_ip=$($cli_exec services ip keys)
   echo -e "Chain at =>\t\t\t\t$chain_ip"
   echo -e "Keys at =>\t\t\t\t$keys_ip"
   echo "Setup complete"

--- a/util/errors.go
+++ b/util/errors.go
@@ -40,12 +40,8 @@ func KeysErrorHandler(do *definitions.Do, err error) (string, error) {
 		return "", fmt.Errorf(`
 Unfortunately the marmots could not find the key you are trying to use in the keys service.
 
-There are two ways to fix this.
-  1. Import your keys from your host: monax keys import %s
-  2. Import your keys from your chain:
-
-monax chains exec %s "mintkey monax chains/%s/priv_validator.json" && \
-monax services exec keys "chown monax:monax -R /home/monax"
+There is one way to fix this.
+  * Import your keys from your host: monax keys import %s
 
 Now, run  monax keys ls  to check that the keys are available. If they are not there
 then change the account. Once you have verified that the keys for account
@@ -53,7 +49,7 @@ then change the account. Once you have verified that the keys for account
 %s
 
 are in the keys service, then rerun me.
-`, do.Package.Account, do.ChainID, do.ChainID, do.Package.Account)
+`, do.Package.Account, do.Package.Account)
 	}
 
 	return "", fmt.Errorf(`


### PR DESCRIPTION
- removes `mintkey`, enabling deprecation of https://github.com/mint-client 
- goes with https://github.com/monax/keys/pull/104
- turns out mintkey was no longer even necessary