### PR TITLE
chains/services: remove ports command

### DIFF
--- a/chains/chains.go
+++ b/chains/chains.go
@@ -144,25 +144,6 @@ func CurrentChain(do *definitions.Do) (string, error) {
 	return head, nil
 }
 
-// PortsChain displays the port mapping for a particular chain.
-// It returns an error.
-//
-//  do.Name - name of the chain to display port mappings for (required)
-//
-func PortsChain(do *definitions.Do) error {
-	chain, err := loaders.LoadChainDefinition(do.Name)
-	if err != nil {
-		return err
-	}
-
-	if util.IsChain(chain.Name, false) {
-		log.WithField("=>", chain.Name).Debug("Getting chain port mapping")
-		return util.PrintPortMappings(chain.Operations.SrvContainerName, do.Operations.Args)
-	}
-
-	return nil
-}
-
 func RemoveChain(do *definitions.Do) error {
 	chain, err := loaders.LoadChainDefinition(do.Name)
 	if err != nil {

--- a/cmd/chains.go
+++ b/cmd/chains.go
@@ -38,7 +38,6 @@ func buildChainsCommand() {
 	Chains.AddCommand(chainsMake)
 	Chains.AddCommand(chainsCheckout)
 	Chains.AddCommand(chainsCurrent)
-	Chains.AddCommand(chainsPorts)
 	Chains.AddCommand(chainsStart)
 	Chains.AddCommand(chainsLogs)
 	Chains.AddCommand(chainsIP)
@@ -98,26 +97,6 @@ passing in a --chain flag. If a --chain is passed to any command accepting
 If command is given without arguments it will clear the head and there will
 be no chain checked out.`,
 	Run: CheckoutChain,
-}
-
-var chainsPorts = &cobra.Command{
-	Use:   "ports NAME [PORT]...",
-	Short: "print port mappings",
-	Long: `print port mappings
-
-The [monax chains ports] command is mostly a developer
-convenience function. It returns a machine readable
-port mapping of a port which is exposed inside the
-container to what that port is mapped to on the host.
-
-This is useful when stitching together chain networks which
-need to know how to connect into a specific chain (perhaps
-with or without a container number) container.`,
-	Example: `$ monax chains ports myChain 1337 -- will display what port on the host is mapped to the monax:db API port
-$ monax chains ports myChain 46656 -- will display what port on the host is mapped to the monax:db peer port
-$ monax chains ports myChain 46657 -- will display what port on the host is mapped to the monax:db rpc port
-$ monax chains ports myChain -- will display all mappings`,
-	Run: PortsChain,
 }
 
 var chainsCurrent = &cobra.Command{
@@ -326,13 +305,6 @@ func CurrentChain(cmd *cobra.Command, args []string) {
 	out, err := chains.CurrentChain(do)
 	util.IfExit(err)
 	fmt.Fprintln(config.Global.Writer, out)
-}
-
-func PortsChain(cmd *cobra.Command, args []string) {
-	util.IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Name = args[0]
-	do.Operations.Args = args[1:]
-	util.IfExit(chains.PortsChain(do))
 }
 
 func IPChain(cmd *cobra.Command, args []string) {

--- a/cmd/services.go
+++ b/cmd/services.go
@@ -29,7 +29,6 @@ func buildServicesCommand() {
 	Services.AddCommand(servicesStart)
 	Services.AddCommand(servicesLogs)
 	Services.AddCommand(servicesIP)
-	Services.AddCommand(servicesPorts)
 	Services.AddCommand(servicesExec)
 	Services.AddCommand(servicesStop)
 	Services.AddCommand(servicesRm)
@@ -65,17 +64,6 @@ var servicesIP = &cobra.Command{
 	Long:  `display service IP`,
 
 	Run: IPService,
-}
-
-var servicesPorts = &cobra.Command{
-	Use:   "ports NAME [PORT]...",
-	Short: "print port mappings",
-	Long: `print port mappings
-
-The [monax services ports] command displays published service ports.`,
-	Example: `$ monax services ports ipfs -- will display all IPFS ports
-$ monax services ports ipfs 4001 5001 -- will display specific IPFS ports`,
-	Run: PortsService,
 }
 
 var servicesLogs = &cobra.Command{
@@ -185,13 +173,6 @@ func IPService(cmd *cobra.Command, args []string) {
 	do.Name = args[0]
 	do.Operations.Args = []string{"NetworkSettings.IPAddress"}
 	util.IfExit(services.InspectService(do))
-}
-
-func PortsService(cmd *cobra.Command, args []string) {
-	util.IfExit(ArgCheck(1, "ge", cmd, args))
-	do.Name = args[0]
-	do.Operations.Args = args[1:]
-	util.IfExit(services.PortsService(do))
 }
 
 func RmService(cmd *cobra.Command, args []string) {

--- a/config/config.go
+++ b/config/config.go
@@ -75,8 +75,7 @@ func LoadViper(definitionPath, definitionName string) (*viper.Viper, error) {
 	// keys.json, keys.yaml, etc.
 
 	if matches, _ := filepath.Glob(filepath.Join(definitionPath, definitionName+".*")); len(matches) == 0 {
-		errKnown := fmt.Sprintf("List available definitions with the [monax %s ls --known] command", filepath.Base(definitionPath))
-		return nil, fmt.Errorf("Unable to find the %q definition: %v\n\n%s", definitionName, os.ErrNotExist, errKnown)
+		return nil, fmt.Errorf("Unable to find the %q definition: %v", definitionName, os.ErrNotExist)
 	}
 
 	conf := viper.New()

--- a/services/services.go
+++ b/services/services.go
@@ -215,20 +215,6 @@ func InspectService(do *definitions.Do) error {
 	return nil
 }
 
-func PortsService(do *definitions.Do) error {
-	service, err := loaders.LoadServiceDefinition(do.Name)
-	if err != nil {
-		return err
-	}
-
-	if util.IsService(service.Service.Name, false) {
-		log.Debug("Service exists, getting port mapping")
-		return util.PrintPortMappings(service.Operations.SrvContainerName, do.Operations.Args)
-	}
-
-	return nil
-}
-
 func LogsService(do *definitions.Do) error {
 	service, err := loaders.LoadServiceDefinition(do.Name)
 	if err != nil {


### PR DESCRIPTION
- removes `monax services ports` and `monax chains ports`; the result of these commands can be gotten elsewhere
- closes #1363