### PR TITLE
update permisions tests to reflect hasBase returning bool

### DIFF
--- a/tests/jobs_fixtures/app33-evm_connection_edb_permissions_and_roles_layer/epm.yaml
+++ b/tests/jobs_fixtures/app33-evm_connection_edb_permissions_and_roles_layer/epm.yaml
@@ -141,7 +141,7 @@ jobs:
     assert:
       key: $checkBase1
       relation: eq
-      val: 1
+      val: "true"
 
 - name: checkBase2
   job:
@@ -152,12 +152,12 @@ jobs:
         - $addr2
         - 14846
 
-- name: assertBase
+- name: assertBase2
   job:
     assert:
       key: $checkBase2
       relation: ne
-      val: 1
+      val: "true"
 
 - name: setBase
   job:
@@ -178,12 +178,12 @@ jobs:
         - $addr2
         - 2119
 
-- name: assertBase
+- name: assertBase3
   job:
     assert:
       key: $checkBase3
       relation: eq
-      val: 1
+      val: "true"
 
 - name: unsetBase
   job:
@@ -203,9 +203,9 @@ jobs:
         - $addr2
         - 2119
 
-- name: assertBase
+- name: assertBase4
   job:
     assert:
       key: $checkBase4
       relation: eq
-      val: 1
+      val: "true"

--- a/tests/jobs_fixtures/app33-evm_connection_edb_permissions_and_roles_layer/permissions.sol
+++ b/tests/jobs_fixtures/app33-evm_connection_edb_permissions_and_roles_layer/permissions.sol
@@ -1,9 +1,13 @@
 pragma solidity >=0.0.0;
 
+// Interface contract below generated from Burrow with 'make snatives'
 /**
 * Interface for managing Secure Native authorizations.
-* @dev This interface describes the functions exposed by the SNative permissions layer in the Monax blockchain (Burrow).
-* @dev These functions can be accessed as if this contract were deployed at the address 0x0000000000000000005065726d697373696f6e73
+* @dev This interface describes the functions exposed by the SNative permissions layer in burrow.
+* @dev These functions can be accessed as if this contract were deployed at a special address (0x0a758feb535243577c1a79ae55bed8ca03e226ec).
+* @dev This special address is defined as the last 20 bytes of the sha3 hash of the the contract name.
+* @dev To instantiate the contract use:
+* @dev Permissions permissions = Permissions(address(sha3("Permissions")));
 */
 contract Permissions {
     /**
@@ -35,7 +39,7 @@ contract Permissions {
     * @param _account account address
     * @param _permission the base permissions flags to set for the account
     * @param _set whether to set or unset the permissions flags at the account level
-    * @return result the resultant permissions flags on the account after the call
+    * @return result the effective permissions flags on the account after the call
     */
     function setBase(address _account, uint64 _permission, bool _set) constant returns (uint64 result);
 
@@ -43,7 +47,7 @@ contract Permissions {
     * @notice Unsets the permissions flags for an account. Causes permissions being unset to fall through to global permissions.
     * @param _account account address
     * @param _permission the permissions flags to unset for the account
-    * @return result the resultant permissions flags on the account after the call
+    * @return result the effective permissions flags on the account after the call
     */
     function unsetBase(address _account, uint64 _permission) constant returns (uint64 result);
 
@@ -53,23 +57,21 @@ contract Permissions {
     * @param _permission the permissions flags (mask) to check whether enabled against base permissions for the account
     * @return result whether account has the passed permissions flags set
     */
-    function hasBase(address _account, uint64 _permission) constant returns (uint64 result);
+    function hasBase(address _account, uint64 _permission) constant returns (bool result);
 
     /**
     * @notice Sets the global (default) permissions flags for the entire chain
     * @param _permission the permissions flags to set
     * @param _set whether to set (or unset) the permissions flags
-    * @return result the resultant permissions flags on the account after the call
+    * @return result the global permissions flags after the call
     */
     function setGlobal(uint64 _permission, bool _set) constant returns (uint64 result);
 }
 
-
 contract permSNative {
-  // github.com/monax/burrow/permission/types/snatives.go#L17
   Permissions perm = Permissions(address(sha3("Permissions")));
 
-  function hasBase(address addr, uint64 permFlag) constant returns (uint64) {
+  function hasBase(address addr, uint64 permFlag) constant returns (bool) {
     return perm.hasBase(addr, permFlag);
   }
 


### PR DESCRIPTION
This updates the epm tests to work against the permissions snative contract after `hasBase` is changed in Burrow to return bool after https://github.com/hyperledger/burrow/pull/606 is merged.