### PR TITLE
compilers: bump version for fixes to #1282

### DIFF
--- a/version/images.go
+++ b/version/images.go
@@ -9,7 +9,7 @@ import (
 const (
 	DB_VERSION        = "0.16.3"
 	KEYS_VERSION      = "0.17.0"
-	COMPILERS_VERSION = "0.17.0"
+	COMPILERS_VERSION = "0.18.0"
 )
 
 var (


### PR DESCRIPTION
- closes #1282 via https://github.com/monax/compilers/pull/135